### PR TITLE
feat: Standardize widget behavior and add unlock threshold setting

### DIFF
--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -130,6 +130,8 @@ This section controls visual indicators to show where and what type of clicks ar
 
 The Scroll tab contains settings for the floating scroll widget and menu widget appearance.
 
+**Note on Widget Behavior**: The scroll and menu widgets are designed to work together. When the menu widget expands (by hovering over the hamburger icon), the scroll widget will automatically hide to reduce clutter, unless you are actively hovering over the scroll widget itself. It will reappear when the menu widget contracts.
+
 ### Scroll Widget
 This section controls a floating scroll widget that appears near your cursor for easy scrolling.
 
@@ -164,6 +166,20 @@ This section controls a floating scroll widget that appears near your cursor for
 - **Increase delay**: If widgets appear too often during normal computer use
 - **Decrease delay**: If you want widgets to be more responsive when you stop moving the cursor
 - **Default (0.2s)**: Good balance for most users
+
+#### Widget Unlock Threshold (100px - 300px)
+**What it does**: Controls the distance (in pixels) your cursor needs to move away from a widget before it "unlocks" and starts following the cursor again.
+
+**Scale**: 100px = unlocks with a small movement, 300px = requires a larger movement to unlock.
+
+**Recommended values**:
+- **100px - 150px**: Widgets feel more "attached" to the cursor and follow it readily. Good for users who prefer responsive widgets.
+- **150px - 200px**: A balanced setting that prevents accidental movement while still being easy to reposition (default: 150px).
+- **200px - 300px**: Widgets are more "sticky" and stay in place until you make a very deliberate movement. Good for users who find the widgets move too often.
+
+**When to adjust**:
+- **Increase threshold**: If you find the widgets move too easily when you're trying to interact with them.
+- **Decrease threshold**: If the widgets feel sluggish or hard to move.
 
 ## General Tab
 

--- a/dwellpy/config/constants.py
+++ b/dwellpy/config/constants.py
@@ -67,6 +67,11 @@ WIDGET_APPEARANCE_DELAY_MIN = 0.1      # Minimum widget appearance delay (second
 WIDGET_APPEARANCE_DELAY_MAX = 1.0      # Maximum widget appearance delay (seconds)  
 WIDGET_APPEARANCE_DELAY_DEFAULT = 0.2  # Default widget appearance delay
 
+# Widget Unlock Threshold Constants
+WIDGET_UNLOCK_THRESHOLD_MIN = 100      # Minimum unlock threshold (pixels)
+WIDGET_UNLOCK_THRESHOLD_MAX = 300      # Maximum unlock threshold (pixels)
+WIDGET_UNLOCK_THRESHOLD_DEFAULT = 150  # Default unlock threshold
+
 # Color Scheme - Dark Theme
 class Colors:
     # Primary colors
@@ -184,6 +189,7 @@ DEFAULT_SETTINGS = {
     'menu_opacity_base': MENU_OPACITY_BASE,
     'menu_opacity_hover': MENU_OPACITY_HOVER,
     'widget_appearance_delay': WIDGET_APPEARANCE_DELAY_DEFAULT,
+    'widget_unlock_threshold': WIDGET_UNLOCK_THRESHOLD_DEFAULT,
     'contract_ui_enabled': False,
     'expansion_direction': DEFAULT_EXPANSION_DIRECTION,
     'click_color_left': '#00e676',

--- a/dwellpy/managers/settings_manager.py
+++ b/dwellpy/managers/settings_manager.py
@@ -12,7 +12,8 @@ from ..config.constants import (
 	MIN_DWELL_TIME, MAX_DWELL_TIME,
 	MIN_TRANSPARENCY, MAX_TRANSPARENCY,
 	EXPANSION_DIRECTIONS,
-	WIDGET_APPEARANCE_DELAY_MIN, WIDGET_APPEARANCE_DELAY_MAX
+	WIDGET_APPEARANCE_DELAY_MIN, WIDGET_APPEARANCE_DELAY_MAX,
+	WIDGET_UNLOCK_THRESHOLD_MIN, WIDGET_UNLOCK_THRESHOLD_MAX
 )
 from ..utils.helpers import get_settings_file_path, get_screen_center, clamp_value
 from ..ui.dialogs.settings_dialog import SettingsDialog
@@ -789,3 +790,23 @@ Keywords=accessibility;dwell;click;motor;disability;
 			self.ui_manager.apply_widget_appearance_settings()
 		
 		self.logger.debug(f"Widget appearance delay updated to: {clamped_delay} seconds")
+	
+	def update_widget_unlock_threshold(self, threshold: int) -> None:
+		"""
+		Update widget unlock threshold setting.
+		
+		Args:
+			threshold: Distance in pixels cursor must move from widget before it starts following again
+		"""
+		# Import constants for validation
+		from ..config.constants import WIDGET_UNLOCK_THRESHOLD_MIN, WIDGET_UNLOCK_THRESHOLD_MAX
+		
+		# Clamp threshold between min and max values
+		clamped_threshold = max(WIDGET_UNLOCK_THRESHOLD_MIN, min(WIDGET_UNLOCK_THRESHOLD_MAX, threshold))
+		self.settings['widget_unlock_threshold'] = clamped_threshold
+		
+		# Apply threshold change immediately if UI manager is available
+		if self.ui_manager:
+			self.ui_manager.apply_widget_unlock_threshold_settings()
+		
+		self.logger.debug(f"Widget unlock threshold updated to: {clamped_threshold} pixels")

--- a/dwellpy/ui/dialogs/settings_dialog.py
+++ b/dwellpy/ui/dialogs/settings_dialog.py
@@ -141,6 +141,21 @@ class SettingsDialog(QDialog):
         self.widget_delay_plus_repeat = QTimer()
         self.widget_delay_plus_repeat.timeout.connect(self.on_hover_plus_widget_delay)
         
+        # Widget unlock threshold timers
+        self.unlock_threshold_minus_timer = QTimer()
+        self.unlock_threshold_minus_timer.setSingleShot(True)
+        self.unlock_threshold_minus_timer.timeout.connect(self.start_minus_unlock_threshold_repeat)
+        
+        self.unlock_threshold_plus_timer = QTimer()
+        self.unlock_threshold_plus_timer.setSingleShot(True)
+        self.unlock_threshold_plus_timer.timeout.connect(self.start_plus_unlock_threshold_repeat)
+        
+        self.unlock_threshold_minus_repeat = QTimer()
+        self.unlock_threshold_minus_repeat.timeout.connect(self.on_hover_minus_unlock_threshold)
+        
+        self.unlock_threshold_plus_repeat = QTimer()
+        self.unlock_threshold_plus_repeat.timeout.connect(self.on_hover_plus_unlock_threshold)
+        
     def setup_ui(self):
         """Setup the dialog UI with left-side wide tabs for dwell-friendly navigation."""
         # Use dynamic sizing instead of fixed size for cross-platform compatibility
@@ -677,6 +692,59 @@ class SettingsDialog(QDialog):
         widget_delay_layout.addWidget(self.widget_delay_value)
         
         layout.addWidget(widget_delay_frame)
+        
+        # Widget Unlock Threshold
+        unlock_threshold_label = QLabel("Widget Unlock Threshold:")
+        unlock_threshold_label.setFont(QFont("Helvetica Neue", 11))
+        unlock_threshold_label.setStyleSheet(f"color: {Colors.TEXT_COLOR}; font-weight: bold;")
+        layout.addWidget(unlock_threshold_label)
+        
+        # Description
+        unlock_desc = QLabel("Distance (in pixels) cursor must move from widget before it starts following again")
+        unlock_desc.setFont(QFont("Helvetica Neue", 9))
+        unlock_desc.setStyleSheet(f"color: #999999; margin-bottom: 8px;")
+        unlock_desc.setWordWrap(True)
+        layout.addWidget(unlock_desc)
+        
+        # Controls frame
+        unlock_threshold_frame = QFrame()
+        unlock_threshold_layout = QHBoxLayout(unlock_threshold_frame)
+        unlock_threshold_layout.setContentsMargins(0, 0, 0, 0)
+        unlock_threshold_layout.setSpacing(5)
+        
+        # Minus button
+        unlock_threshold_minus_btn = self.create_adjustment_button("-")
+        unlock_threshold_minus_btn.enterEvent = lambda e: self.on_enter_minus_unlock_threshold()
+        unlock_threshold_minus_btn.leaveEvent = lambda e: self.on_leave_minus_unlock_threshold()
+        unlock_threshold_layout.addWidget(unlock_threshold_minus_btn)
+        
+        # Slider (10-30, representing 100-300 pixels)
+        self.unlock_threshold_slider = QSlider(Qt.Orientation.Horizontal)
+        self.unlock_threshold_slider.setRange(10, 30)
+        # Convert current threshold (100-300) to slider value (10-30)
+        current_threshold = self.settings_manager.get_setting('widget_unlock_threshold', 150)
+        slider_value = current_threshold // 10
+        self.unlock_threshold_slider.setValue(max(10, min(30, slider_value)))
+        self.unlock_threshold_slider.setStyleSheet(self.get_slider_style())
+        unlock_threshold_layout.addWidget(self.unlock_threshold_slider)
+        
+        # Plus button
+        unlock_threshold_plus_btn = self.create_adjustment_button("+")
+        unlock_threshold_plus_btn.enterEvent = lambda e: self.on_enter_plus_unlock_threshold()
+        unlock_threshold_plus_btn.leaveEvent = lambda e: self.on_leave_plus_unlock_threshold()
+        unlock_threshold_layout.addWidget(unlock_threshold_plus_btn)
+        
+        # Value label
+        threshold_pixels = self.unlock_threshold_slider.value() * 10
+        self.unlock_threshold_value = QLabel(f"{threshold_pixels}px")
+        self.unlock_threshold_value.setStyleSheet(f"""
+            {self._get_scaled_font_style(13, "bold")}
+            color: {Colors.TEXT_COLOR};
+        """)
+        self.unlock_threshold_value.setFixedWidth(50)
+        unlock_threshold_layout.addWidget(self.unlock_threshold_value)
+        
+        layout.addWidget(unlock_threshold_frame)
     
     def create_active_state_section(self, layout):
         """Create default active state section."""
@@ -1001,6 +1069,7 @@ class SettingsDialog(QDialog):
         self.contract_ui_check.stateChanged.connect(self.on_contract_ui_toggle)
         self.expansion_button_group.buttonClicked.connect(self.on_expansion_direction_toggle)
         self.widget_delay_slider.valueChanged.connect(self.update_widget_delay_value)
+        self.unlock_threshold_slider.valueChanged.connect(self.update_unlock_threshold_value)
     
     # Value update methods
     def update_move_limit_value(self, value):
@@ -1036,6 +1105,12 @@ class SettingsDialog(QDialog):
         delay_seconds = value / 10.0
         self.widget_delay_value.setText(f"{delay_seconds:.1f}s")
         self.settings_manager.update_widget_appearance_delay(delay_seconds)
+    
+    def update_unlock_threshold_value(self, value):
+        """Update unlock threshold display value."""
+        threshold_pixels = value * 10
+        self.unlock_threshold_value.setText(f"{threshold_pixels}px")
+        self.settings_manager.update_widget_unlock_threshold(threshold_pixels)
 
     def on_scroll_toggle(self, state):
         """Handle scroll widget checkbox toggle."""
@@ -1165,6 +1240,24 @@ class SettingsDialog(QDialog):
         self.widget_delay_plus_timer.stop()
         self.widget_delay_plus_repeat.stop()
     
+    def on_enter_minus_unlock_threshold(self):
+        """Start minus unlock threshold timer on hover."""
+        self.unlock_threshold_minus_timer.start(500)
+    
+    def on_leave_minus_unlock_threshold(self):
+        """Stop minus unlock threshold timer on leave."""
+        self.unlock_threshold_minus_timer.stop()
+        self.unlock_threshold_minus_repeat.stop()
+    
+    def on_enter_plus_unlock_threshold(self):
+        """Start plus unlock threshold timer on hover."""
+        self.unlock_threshold_plus_timer.start(500)
+    
+    def on_leave_plus_unlock_threshold(self):
+        """Stop plus unlock threshold timer on leave."""
+        self.unlock_threshold_plus_timer.stop()
+        self.unlock_threshold_plus_repeat.stop()
+    
     # Timer start methods that begin the repeat action
     def start_minus_move_repeat(self):
         self.on_hover_minus_move_limit()  # First action
@@ -1205,6 +1298,14 @@ class SettingsDialog(QDialog):
     def start_plus_widget_delay_repeat(self):
         self.on_hover_plus_widget_delay()
         self.widget_delay_plus_repeat.start(500)
+    
+    def start_minus_unlock_threshold_repeat(self):
+        self.on_hover_minus_unlock_threshold()
+        self.unlock_threshold_minus_repeat.start(500)
+        
+    def start_plus_unlock_threshold_repeat(self):
+        self.on_hover_plus_unlock_threshold()
+        self.unlock_threshold_plus_repeat.start(500)
     
     # The actual value adjustment methods
     def on_hover_minus_move_limit(self):
@@ -1257,6 +1358,16 @@ class SettingsDialog(QDialog):
         if current < self.widget_delay_slider.maximum():
             self.widget_delay_slider.setValue(current + 1)
     
+    def on_hover_minus_unlock_threshold(self):
+        current = self.unlock_threshold_slider.value()
+        if current > self.unlock_threshold_slider.minimum():
+            self.unlock_threshold_slider.setValue(current - 1)
+        
+    def on_hover_plus_unlock_threshold(self):
+        current = self.unlock_threshold_slider.value()
+        if current < self.unlock_threshold_slider.maximum():
+            self.unlock_threshold_slider.setValue(current + 1)
+    
     def accept(self):
         """Handle dialog acceptance."""
         # Stop all timers
@@ -1266,11 +1377,13 @@ class SettingsDialog(QDialog):
             self.transparency_minus_timer, self.transparency_plus_timer,
             self.scroll_speed_minus_timer, self.scroll_speed_plus_timer,
             self.widget_delay_minus_timer, self.widget_delay_plus_timer,
+            self.unlock_threshold_minus_timer, self.unlock_threshold_plus_timer,
             self.move_minus_repeat, self.move_plus_repeat, 
             self.time_minus_repeat, self.time_plus_repeat,
             self.transparency_minus_repeat, self.transparency_plus_repeat,
             self.scroll_speed_minus_repeat, self.scroll_speed_plus_repeat,
-            self.widget_delay_minus_repeat, self.widget_delay_plus_repeat
+            self.widget_delay_minus_repeat, self.widget_delay_plus_repeat,
+            self.unlock_threshold_minus_repeat, self.unlock_threshold_plus_repeat
         ]
         
         for timer in timers_to_stop:

--- a/dwellpy/ui/menu_widget.py
+++ b/dwellpy/ui/menu_widget.py
@@ -81,7 +81,7 @@ class MenuWidget(QWidget):
         # Position lock state - keeping existing lock logic for accessibility
         self.is_locked = False  # Whether widget is locked in position
         self.lock_threshold = 120  # Distance to lock
-        self.unlock_threshold = 150  # Distance to resume following
+        self.unlock_threshold = 180  # Distance to resume following (will be set by settings)
         
         # Movement tracking to prevent false hover detection
         self.last_move_time = 0

--- a/dwellpy/ui/menu_widget.py
+++ b/dwellpy/ui/menu_widget.py
@@ -387,7 +387,7 @@ class MenuWidget(QWidget):
         self.move(position[0], position[1])
         self.last_widget_pos = position
     
-    def update_position(self, cursor_pos, coordinated_mode=False):
+    def update_position(self, cursor_pos, coordinated_mode=False, y_offset=0):
         """Update widget position relative to cursor, with optional coordinated mode."""
         if not self.is_active:
             return
@@ -445,7 +445,7 @@ class MenuWidget(QWidget):
             # Position widget so hamburger icon is centered under cursor
             widget_size = self.expanded_size if self.is_expanded else self.hamburger_size
             new_x = int(cursor_x - widget_size // 2)
-            new_y = int(cursor_y - widget_size // 2)
+            new_y = int(cursor_y - widget_size // 2) + y_offset
             
             # Check if widget actually needs to move
             if self.last_widget_pos is not None:
@@ -478,7 +478,7 @@ class MenuWidget(QWidget):
                 # Immediately update to new position centered under cursor
                 widget_size = self.expanded_size if self.is_expanded else self.hamburger_size
                 new_x = int(cursor_x - widget_size // 2)
-                new_y = int(cursor_y - widget_size // 2)
+                new_y = int(cursor_y - widget_size // 2) + y_offset
                 
                 # Check for screen bounds and adjust position if necessary
                 off_screen_info = self._detect_off_screen_position(QPoint(new_x, new_y), self.size())

--- a/dwellpy/ui/menu_widget.py
+++ b/dwellpy/ui/menu_widget.py
@@ -81,7 +81,7 @@ class MenuWidget(QWidget):
         # Position lock state - keeping existing lock logic for accessibility
         self.is_locked = False  # Whether widget is locked in position
         self.lock_threshold = 120  # Distance to lock
-        self.unlock_threshold = 180  # Distance to resume following
+        self.unlock_threshold = 150  # Distance to resume following
         
         # Movement tracking to prevent false hover detection
         self.last_move_time = 0

--- a/dwellpy/ui/scroll_widget.py
+++ b/dwellpy/ui/scroll_widget.py
@@ -70,7 +70,7 @@ class ScrollWidget(QWidget):
         # Position lock state
         self.is_locked = False  # Whether widget is locked in position
         self.lock_threshold = 140  # Distance to lock (must be greater than offset_distance)
-        self.unlock_threshold = 200  # Distance to resume following
+        self.unlock_threshold = 150  # Distance to resume following
         
         # Movement tracking to prevent false hover detection
         self.last_move_time = 0

--- a/dwellpy/ui/scroll_widget.py
+++ b/dwellpy/ui/scroll_widget.py
@@ -70,7 +70,7 @@ class ScrollWidget(QWidget):
         # Position lock state
         self.is_locked = False  # Whether widget is locked in position
         self.lock_threshold = 140  # Distance to lock (must be greater than offset_distance)
-        self.unlock_threshold = 150  # Distance to resume following
+        self.unlock_threshold = 180  # Distance to resume following (will be set by settings)
         
         # Movement tracking to prevent false hover detection
         self.last_move_time = 0

--- a/dwellpy/ui/ui_manager.py
+++ b/dwellpy/ui/ui_manager.py
@@ -255,6 +255,9 @@ class DwellClickerUI:
         
         # Apply widget appearance settings
         self.apply_widget_appearance_settings()
+        
+        # Apply widget unlock threshold settings
+        self.apply_widget_unlock_threshold_settings()
     
     def register_button_commands(self):
         """Register button commands with the button manager."""
@@ -1659,7 +1662,7 @@ class DwellClickerUI:
             
             # Use lock thresholds similar to individual widgets
             lock_threshold = 120
-            unlock_threshold = 150
+            unlock_threshold = self.settings_manager.get_setting('widget_unlock_threshold', 150)
             
             # Check if either widget is close enough to lock both
             should_lock = (scroll_distance < lock_threshold or menu_distance < lock_threshold)
@@ -2143,6 +2146,21 @@ class DwellClickerUI:
         
         # Update the movement detector with the new delay
         self.cursor_movement_detector.set_dwell_delay(appearance_delay)
+    
+    def apply_widget_unlock_threshold_settings(self):
+        """Apply widget unlock threshold settings to all widgets."""
+        if not self.settings_manager:
+            return
+            
+        threshold = self.settings_manager.get_setting('widget_unlock_threshold', 150)
+        
+        # Update threshold in scroll widget
+        if hasattr(self, 'scroll_widget') and self.scroll_widget:
+            self.scroll_widget.unlock_threshold = threshold
+            
+        # Update threshold in menu widget
+        if hasattr(self, 'menu_widget') and self.menu_widget:
+            self.menu_widget.unlock_threshold = threshold
         
         # Sync movement threshold with dwell detection move_limit
         if hasattr(self, 'dwell_detector') and self.dwell_detector:

--- a/dwellpy/ui/ui_manager.py
+++ b/dwellpy/ui/ui_manager.py
@@ -1582,8 +1582,8 @@ class DwellClickerUI:
                 # Just handle hover detection here
                 pass
             else:
-                # Normal positioning if scroll is disabled
-                self.menu_widget.update_position(cursor_pos)
+                # Normal positioning if scroll is disabled, with a 20px offset
+                self.menu_widget.update_position(cursor_pos, y_offset=20)
             
             # Check for hover on menu widget
             hover = self.menu_widget.check_hover(cursor_pos)

--- a/dwellpy/ui/ui_manager.py
+++ b/dwellpy/ui/ui_manager.py
@@ -1516,8 +1516,23 @@ class DwellClickerUI:
                 # Coordinated positioning mode
                 self._update_coordinated_widget_positions(cursor_pos)
             else:
-                # Normal positioning if menu is disabled
-                self.scroll_widget.update_position(cursor_pos)
+                # Normal positioning if menu is disabled, but still check if menu is expanded
+                menu_expanded = hasattr(self.menu_widget, 'is_expanded') and self.menu_widget.is_expanded
+                scroll_activated = self.scroll_hover is not None
+                
+                # Hide scroll widget if menu is expanded and scroll is not activated
+                if menu_expanded and not scroll_activated:
+                    if self.scroll_widget.isVisible():
+                        self.scroll_widget.hide()
+                else:
+                    # Show and position scroll widget normally
+                    if not self.scroll_widget.isVisible():
+                        self.scroll_widget.show()
+                        self.scroll_widget.setWindowOpacity(self.scroll_widget.base_opacity)
+                        # Only raise on non-macOS platforms to prevent focus stealing
+                        if sys.platform != "darwin":
+                            self.scroll_widget.raise_()
+                    self.scroll_widget.update_position(cursor_pos)
             
             # Check for hover on scroll widget
             hover = self.scroll_widget.check_hover(cursor_pos)
@@ -1606,6 +1621,28 @@ class DwellClickerUI:
         # Initialize coordinated lock state if not exists
         if not hasattr(self, '_coordinated_locked'):
             self._coordinated_locked = False
+        
+        # Check if menu widget is expanded and scroll widget should be hidden
+        menu_expanded = hasattr(self.menu_widget, 'is_expanded') and self.menu_widget.is_expanded
+        scroll_activated = self.scroll_hover is not None
+        
+        # Hide scroll widget if menu is expanded and scroll is not activated
+        if menu_expanded and not scroll_activated:
+            if self.scroll_widget.isVisible():
+                self.scroll_widget.hide()
+            # Only position menu widget in this case
+            self.menu_widget.update_position(cursor_pos, coordinated_mode=True)
+            return
+        
+        # Show scroll widget if it should be visible (menu not expanded or scroll is activated)
+        scroll_enabled = self.settings_manager.get_setting('scroll_enabled', True)
+        if scroll_enabled and self.is_active and not self.widgets_hidden_for_movement:
+            if not self.scroll_widget.isVisible():
+                self.scroll_widget.show()
+                self.scroll_widget.setWindowOpacity(self.scroll_widget.base_opacity)
+                # Only raise on non-macOS platforms to prevent focus stealing
+                if sys.platform != "darwin":
+                    self.scroll_widget.raise_()
         
         # Check if widgets should be locked based on cursor proximity
         # Only check if widgets are visible and have been positioned

--- a/dwellpy/ui/ui_manager.py
+++ b/dwellpy/ui/ui_manager.py
@@ -1659,7 +1659,7 @@ class DwellClickerUI:
             
             # Use lock thresholds similar to individual widgets
             lock_threshold = 120
-            unlock_threshold = 180
+            unlock_threshold = 150
             
             # Check if either widget is close enough to lock both
             should_lock = (scroll_distance < lock_threshold or menu_distance < lock_threshold)


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

This pull request introduces two main enhancements to improve widget usability and customization, and one bug fix for consistent widget positioning:

1.  **Hides the scroll widget when the menu widget expands:** This prevents visual clutter and improves user experience. The scroll widget is only hidden if it is not currently activated (being hovered over), ensuring users can still access scroll functionality when needed.
2.  **Adds a user-configurable setting for the widget unlock threshold:** This allows users to customize how responsive the widgets are to cursor movement.
3.  **Fixes inconsistent menu widget positioning:** The menu widget now consistently appears 20px below the cursor and locks correctly, regardless of whether the scroll widget is enabled or disabled.

## 🔧 Changes Made

-   **Widget Positioning & Locking Fix:**
    -   Added a `y_offset` parameter to `MenuWidget.update_position()` to allow for consistent vertical offsets.
    -   Refactored `UIManager.update_menu_widget_position()` to use the new `y_offset` parameter, ensuring the menu widget is correctly positioned and handles its own locking logic when the scroll widget is disabled.
-   **Hide Scroll Widget on Menu Expansion:**
    -   Updated `_update_coordinated_widget_positions()` to hide the scroll widget when the menu is expanded and the scroll widget is not active.
    -   Added similar logic to `update_scroll_widget_position()` for non-coordinated mode.
-   **Configurable Unlock Threshold:**
    -   Added a "Widget Unlock Threshold" slider to the settings dialog (`settings_dialog.py`), allowing adjustment from 100px to 300px.
    -   The scroll widget, menu widget, and coordinated positioning logic now use this new setting from `SettingsManager`.
    -   Updated `SettingsManager` to handle saving and applying the `widget_unlock_threshold` setting.
    -   Added `apply_widget_unlock_threshold_settings` to `UIManager` to apply the setting dynamically.
-   **Documentation:**
    -   Updated `docs/configuration_guide.md` to document the new features and behaviors.

## 🧪 How to Test

1.  Launch the application.
2.  Disable the scroll widget from the main UI's "SCROLL" button.
3.  **Verify:** The menu widget appears 20px below the cursor and correctly locks in place when hovered.
4.  Enable the scroll widget again.
5.  Hover over the menu widget to expand it.
6.  **Verify:** The scroll widget disappears.
7.  Move the cursor over the scroll widget's original location while the menu is expanded.
8.  **Verify:** The scroll widget reappears and can be used.
9.  Open the settings dialog from the "SETUP" button.
10. Navigate to the "Scroll" tab.
11. Adjust the "Widget Unlock Threshold" slider.
12. **Verify:** The widgets' responsiveness to cursor locking and following changes according to the new value.

## ✅ Checklist

-   [x] I have tested my changes locally
-   [ ] I have added or updated tests where necessary
-   [x] I have updated documentation (if needed)
-   [ ] I have verified the `release-please` config/versioning if this is a release-related change
-   [x] My code follows the project's coding style